### PR TITLE
Store embedding vectors with float32

### DIFF
--- a/fasttext.go
+++ b/fasttext.go
@@ -1,6 +1,6 @@
 /*
 Package fasttext provides a simple wrapper for Facebook
-fastText dataset (https://github.com/facebookresearch/fastText/blob/master/pretrained-vectors.md).
+fastText dataset (https://fasttext.cc/docs/en/crawl-vectors.html).
 It allows fast look-up of word embeddings from persistent data store (SQLite3).
 
 Installation
@@ -16,7 +16,8 @@ you can initialize the SQLite3 database (in your code):
 	)
 	...
 	ft := fasttext.NewFastText("/path/to/sqlite3/file")
-	err := ft.BuilDB("/path/to/word/embedding/.vec/file")
+	vecFile, err := os.Open("/path/to/word/embedding/.vec/file")
+	err = ft.BuildDB(vecFile)
 
 This will create a new file on your disk for the SQLite3 database.
 Once the above step is finished, you can start looking up word embeddings
@@ -132,9 +133,9 @@ func (ft *FastText) GetEmb(word string) ([]float64, error) {
 	return bytesToVec(binVec, ByteOrder)
 }
 
-// BuildDB initialize the SQLite3 database by importing the word embeddings
+// BuildDB initializes the SQLite3 database by importing the word embeddings
 // from the .vec file downloaded from
-// https://github.com/facebookresearch/fastText/blob/master/pretrained-vectors.md
+// https://fasttext.cc/docs/en/crawl-vectors.html
 func (ft *FastText) BuildDB(wordEmbFile io.Reader) error {
 	_, err := ft.db.Exec(`
 	CREATE TABLE fasttext(

--- a/fasttext.go
+++ b/fasttext.go
@@ -105,10 +105,6 @@ func NewFastTextInMem(dbFilename string) *FastText {
 	if err != nil {
 		panic(err)
 	}
-	_, err = db.Exec(`CREATE INDEX inx_ft ON fasttext(word);`)
-	if err != nil {
-		panic(err)
-	}
 	return &FastText{
 		db: db,
 	}
@@ -155,11 +151,6 @@ func (ft *FastText) BuildDB(wordEmbFile io.Reader) error {
 		if _, err := stmt.Exec(emb.Word, binVec); err != nil {
 			return err
 		}
-	}
-	// Indexing on words
-	_, err = ft.db.Exec(`CREATE INDEX ind_word ON fasttext(word);`)
-	if err != nil {
-		return err
 	}
 	return nil
 }

--- a/util.go
+++ b/util.go
@@ -8,7 +8,7 @@ import (
 func vecToBytes(vec []float64, order binary.ByteOrder) []byte {
 	buf := new(bytes.Buffer)
 	for _, v := range vec {
-		binary.Write(buf, order, v)
+		binary.Write(buf, order, float32(v))
 	}
 	return buf.Bytes()
 }
@@ -17,12 +17,12 @@ func bytesToVec(data []byte, order binary.ByteOrder) ([]float64, error) {
 	size := len(data) / 8
 	vec := make([]float64, size)
 	buf := bytes.NewReader(data)
-	var v float64
+	var v float32
 	for i := range vec {
 		if err := binary.Read(buf, order, &v); err != nil {
 			return nil, err
 		}
-		vec[i] = v
+		vec[i] = float64(v)
 	}
 	return vec, nil
 }


### PR DESCRIPTION
Using float32 reduced the size of the database from 7.7G to 2.6G. fastText uses 32-bit floats internally.
SQLite automatically creates an index on words because they are unique, and this is the index that is used according to `explain query plan`, so I removed the manually created index. 