### PR TITLE
Fix bytesToVec bug, return []float32 from GetEmb

### DIFF
--- a/fasttext.go
+++ b/fasttext.go
@@ -29,7 +29,7 @@ Once the above step is finished, you can start looking up word embeddings
 	}
 	fmt.Println(emb)
 
-Each word embedding vector is a slice of float64 with length of 300.
+Each word embedding vector is a slice of float32 with length of 300.
 
 Note that you only need to initialize the SQLite3 database once.
 The next time you use it you can skip the call to BuildDB.
@@ -117,7 +117,7 @@ func (ft *FastText) Close() error {
 }
 
 // GetEmb returns the word embedding of the given word.
-func (ft *FastText) GetEmb(word string) ([]float64, error) {
+func (ft *FastText) GetEmb(word string) ([]float32, error) {
 	var binVec []byte
 	err := ft.db.QueryRow(`SELECT emb FROM fasttext WHERE word=?;`, word).Scan(&binVec)
 	if err == sql.ErrNoRows {
@@ -157,7 +157,7 @@ func (ft *FastText) BuildDB(wordEmbFile io.Reader) error {
 
 type wordEmb struct {
 	Word string
-	Vec  []float64
+	Vec  []float32
 }
 
 func readwordEmbdFile(wordEmbFile io.Reader) chan *wordEmb {
@@ -191,13 +191,13 @@ func readwordEmbdFile(wordEmbFile io.Reader) chan *wordEmb {
 					embSize, len(vecStrs), line, word)
 				panic(msg)
 			}
-			vec := make([]float64, embSize)
+			vec := make([]float32, embSize)
 			for i := 0; i < embSize; i++ {
-				sf, err := strconv.ParseFloat(vecStrs[i], 64)
+				sf, err := strconv.ParseFloat(vecStrs[i], 32)
 				if err != nil {
 					panic(err)
 				}
-				vec[i] = sf
+				vec[i] = float32(sf)
 			}
 			out <- &wordEmb{
 				Word: word,

--- a/util.go
+++ b/util.go
@@ -5,24 +5,24 @@ import (
 	"encoding/binary"
 )
 
-func vecToBytes(vec []float64, order binary.ByteOrder) []byte {
+func vecToBytes(vec []float32, order binary.ByteOrder) []byte {
 	buf := new(bytes.Buffer)
 	for _, v := range vec {
-		binary.Write(buf, order, float32(v))
+		binary.Write(buf, order, v)
 	}
 	return buf.Bytes()
 }
 
-func bytesToVec(data []byte, order binary.ByteOrder) ([]float64, error) {
+func bytesToVec(data []byte, order binary.ByteOrder) ([]float32, error) {
 	size := len(data) / 4
-	vec := make([]float64, size)
+	vec := make([]float32, size)
 	buf := bytes.NewReader(data)
 	var v float32
 	for i := range vec {
 		if err := binary.Read(buf, order, &v); err != nil {
 			return nil, err
 		}
-		vec[i] = float64(v)
+		vec[i] = v
 	}
 	return vec, nil
 }

--- a/util.go
+++ b/util.go
@@ -14,7 +14,7 @@ func vecToBytes(vec []float64, order binary.ByteOrder) []byte {
 }
 
 func bytesToVec(data []byte, order binary.ByteOrder) ([]float64, error) {
-	size := len(data) / 8
+	size := len(data) / 4
 	vec := make([]float64, size)
 	buf := bytes.NewReader(data)
 	var v float32


### PR DESCRIPTION
I missed one change in bytesToVec in the last PR.
I also made GetEmb return slice of float32 instead of float64 to avoid a conversion in bytesToVec. If a slice of float64 is needed, the conversion can be done in the user's code. Otherwise, no conversion is necessary.